### PR TITLE
Adding a basic Rust devcontainer for Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:1.66
+
+WORKDIR /home/
+
+COPY . .
+
+RUN bash ./setup.sh

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:1.66
+FROM rust:1.66
 
 WORKDIR /home/
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+    "name": "Node Typescript Codespace",
+    "hostRequirements": {
+        "cpus": 4,
+        "memory": "8gb",
+        "storage": "32gb" 
+     },
+    "extensions": [
+		"coenraads.bracket-pair-colorizer-2",
+		"github.vscode-pull-request-github",
+        "ms-azuretools.vscode-docker",
+        "rust-lang.rust-analyzer"
+	],
+    "dockerFile": "Dockerfile",
+    "settings": {
+        "terminal.integrated.shell.linux": "/usr/bin/zsh",
+        "files.exclude": {
+            "**/CODE_OF_CONDUCT.md": true,
+            "**/LICENSE": true
+        }
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:1": {
+            "version": "latest"
+        }
+    }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Node Typescript Codespace",
+    "name": "Rust Codespace",
     "hostRequirements": {
         "cpus": 4,
         "memory": "8gb",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,10 +6,11 @@
         "storage": "32gb" 
      },
     "extensions": [
-		"coenraads.bracket-pair-colorizer-2",
-		"github.vscode-pull-request-github",
+		"github.codespaces",
+        "rust-lang.rust-analyzer",
+        "coenraads.bracket-pair-colorizer-2",
         "ms-azuretools.vscode-docker",
-        "rust-lang.rust-analyzer"
+		"github.vscode-pull-request-github"
 	],
     "dockerFile": "Dockerfile",
     "settings": {

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,9 @@
+## update and install some things we should probably have
+apt-get update
+apt-get install -y \
+  curl \
+  git \
+  gnupg2 \
+  jq \
+  sudo \
+  zsh


### PR DESCRIPTION
This PR adds a starter Rust (and Docker) devcontainer for Codespaces.

I tested it by rebuilding the Codespace without errors and running `cargo build` that returned expected errors from @peterms2021 refactoring in progress.

_I tend to start with a basic Codespace w/o terminal/shell customizations and let the team put in what they want._

closes #1 